### PR TITLE
Add more private IP ranges and disable unneeded module

### DIFF
--- a/unbound.conf
+++ b/unbound.conf
@@ -22,6 +22,9 @@ server:
     private-address: 192.168.0.0/16
     private-address: 172.16.0.0/12
     private-address: 10.0.0.0/8
+    private-address: 169.254.0.0/16
+    private-address: fd00::/8
+    private-address: fe80::/10
     hide-identity: yes
     hide-version: yes
     harden-glue: yes
@@ -37,3 +40,4 @@ server:
     val-clean-additional: yes
     val-sig-skew-max: 0
     val-sig-skew-min: 0
+    ipsecmod-enabled: no


### PR DESCRIPTION
The private IP addresses are listed at https://nlnetlabs.nl/documentation/unbound/unbound.conf/ 
```
 No  private  addresses  are
              enabled  by default.  We consider to enable this for the RFC1918
              private IP address space by  default  in  later  releases.  That
              would  enable  private  addresses  for  10.0.0.0/8 172.16.0.0/12
              192.168.0.0/16 169.254.0.0/16 fd00::/8 and fe80::/10, since  the
              RFC  standards  say these addresses should not be visible on the
              public internet.
```