### PR TITLE
Update configuration options for more helpful logging

### DIFF
--- a/unbound.conf
+++ b/unbound.conf
@@ -8,6 +8,9 @@ server:
     username: ""
     log-replies: yes
     log-queries: yes
+    log-tag-queryreply: yes
+    log-servfail: yes
+    val-log-level: 2
     num-threads: 1
     so-reuseport: yes
     verbosity: 2


### PR DESCRIPTION
Hello! This PR introduces the following configuration options in an attempt to give more debug information to users:
- `log-tag-queyreply`; uses "query" and "reply" instead of "info" in order to differentiate the client facing queries and replies from the ones that are generated during resolving;
- `log-servfail`; prints the reason Unbound SERVFAIL's a given query;
- `val-log-level`; if the SERVFAIL was because of DNSSEC the validator module will provide as much information is available to the SERVFAIL entry above.