### PR TITLE
fix: use ubuntu:23.04 as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
-FROM ubuntu:focal
+FROM ubuntu:23.04
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt update && apt -y install unbound golang-go ca-certificates
+RUN apt update && apt -y install unbound golang-go ca-certificates git
 COPY . /unboundtest
 WORKDIR /unboundtest
 RUN GOBIN=/usr/bin go install ./
 RUN mkdir -p /var/run/unboundtest
 COPY index.html root.key unbound.conf /var/run/unboundtest/
+COPY root.key unbound.conf /etc/unbound
 WORKDIR /var/run/unboundtest
 EXPOSE 1232
 CMD ["/usr/bin/unboundtest"]

--- a/unbound.conf
+++ b/unbound.conf
@@ -1,11 +1,11 @@
 server:
     edns-buffer-size: 512
     directory: "."
-    auto-trust-anchor-file: "root.key"
+    auto-trust-anchor-file: "/etc/unbound/root.key"
     pidfile: ""
     logfile: ""
     chroot: ""
-    username: ""
+    username: "root"
     log-replies: yes
     log-queries: yes
     num-threads: 1
@@ -14,7 +14,7 @@ server:
     use-syslog: no
     log-time-ascii: yes
     do-ip4: yes
-    do-ip6: yes
+    do-ip6: no
     do-udp: yes
     do-tcp: yes
     tcp-upstream: no

--- a/unboundtest.go
+++ b/unboundtest.go
@@ -18,7 +18,7 @@ import (
 	"github.com/miekg/dns"
 )
 
-const unboundConfig = "unbound.conf"
+const unboundConfig = "/etc/unbound/unbound.conf"
 
 // A regexp for reasonable close-to-valid DNS names
 var dnsish = regexp.MustCompile("^[A-Za-z0-9-_.]+$")


### PR DESCRIPTION
- Use ubuntu:23.04 as base image, as its the minimum image with upbound 1.14.
- Reconfigure unboundtest to b able to use `unbound.conf`  from `/etc/unbound`