### PR TITLE
Add support for dynamically-chosen IP:Ports for both the unboundtest and unbound services.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,8 @@ Usage of unboundtest:
     	The address on which to listen for incoming Web requests (default ":1232")
   -unboundAddress string
     	The address the unbound.conf instructs Unbound to listen on (default "127.0.0.1:1053")
+  -unboundConfig string
+    	The path to the unbound.conf file (default "unbound.conf")
+  -unboundExec string
+    	The path to the unbound executable (default "unbound")
 ```

--- a/README.md
+++ b/README.md
@@ -26,11 +26,13 @@ unboundtest container, and visit that IP address on port 1232.
 ```
 Usage of unboundtest:
   -listen string
-    	The address on which to listen for incoming Web requests (default ":1232")
+        The address on which to listen for incoming Web requests (default ":1232")
   -unboundAddress string
-    	The address the unbound.conf instructs Unbound to listen on (default "127.0.0.1:1053")
+        The address the unbound.conf instructs Unbound to listen on (default "127.0.0.1:1053")
   -unboundConfig string
-    	The path to the unbound.conf file (default "unbound.conf")
+        The path to the unbound.conf file (default "unbound.conf")
   -unboundExec string
-    	The path to the unbound executable (default "unbound")
+        The path to the unbound executable (default "unbound")
+  -index string
+        The path to the index.html (default "index.html")
 ```

--- a/README.md
+++ b/README.md
@@ -21,3 +21,12 @@ docker run unboundtest
 
 Then use `docker ps` and `docker inspect` to find the IP address of the
 unboundtest container, and visit that IP address on port 1232.
+
+## CLI
+```
+Usage of unboundtest:
+  -listen string
+    	The address on which to listen for incoming Web requests (default ":1232")
+  -unboundAddress string
+    	The address the unbound.conf instructs Unbound to listen on (default "127.0.0.1:1053")
+```

--- a/unboundtest.go
+++ b/unboundtest.go
@@ -19,8 +19,6 @@ import (
 	"github.com/miekg/dns"
 )
 
-const unboundConfig = "unbound.conf"
-
 // A regexp for reasonable close-to-valid DNS names
 var dnsish = regexp.MustCompile("^[A-Za-z0-9-_.]+$")
 
@@ -29,6 +27,8 @@ var unboundMutex sync.Mutex
 
 var listenAddr = flag.String("listen", ":1232", "The address on which to listen for incoming Web requests")
 var unboundAddr = flag.String("unboundAddress", "127.0.0.1:1053", "The address the unbound.conf instructs Unbound to listen on")
+var unboundConfig = flag.String("unboundConfig", "unbound.conf", "The path to the unbound.conf file")
+var unboundExec = flag.String("unboundExec", "unbound", "The path to the unbound executable")
 
 func main() {
 	flag.Parse()
@@ -55,7 +55,7 @@ func indexHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func configHandler(w http.ResponseWriter, r *http.Request) {
-	file, err := os.Open(unboundConfig)
+	file, err := os.Open(*unboundConfig)
 	if err != nil {
 		fmt.Fprintln(w, err)
 		return
@@ -139,7 +139,7 @@ func doQuery(ctx context.Context, q string, typ uint16, w io.Writer) error {
 		q = q + "."
 	}
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	cmd := exec.CommandContext(ctx, "unbound", "-d", "-c", unboundConfig)
+	cmd := exec.CommandContext(ctx, *unboundExec, "-d", "-c", *unboundConfig)
 	defer func() {
 		cancel()
 		cmd.Wait()

--- a/unboundtest.go
+++ b/unboundtest.go
@@ -29,6 +29,7 @@ var listenAddr = flag.String("listen", ":1232", "The address on which to listen 
 var unboundAddr = flag.String("unboundAddress", "127.0.0.1:1053", "The address the unbound.conf instructs Unbound to listen on")
 var unboundConfig = flag.String("unboundConfig", "unbound.conf", "The path to the unbound.conf file")
 var unboundExec = flag.String("unboundExec", "unbound", "The path to the unbound executable")
+var indexFile = flag.String("index", "index.html", "The path to index.html")
 
 func main() {
 	flag.Parse()
@@ -44,7 +45,7 @@ func indexHandler(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	file, err := os.Open("index.html")
+	file, err := os.Open(*indexFile)
 	if err != nil {
 		fmt.Fprintln(w, err)
 		return


### PR DESCRIPTION
There are now optional CLI arguments:
```
Usage of unboundtest:
  -listen string
        The address on which to listen for incoming Web requests (default ":1232")
  -unboundAddress string
        The address the unbound.conf instructs Unbound to listen on (default "127.0.0.1:1053")
  -unboundConfig string
        The path to the unbound.conf file (default "unbound.conf")
  -unboundExec string
        The path to the unbound executable (default "unbound")
  -index string
        The path to the index.html (default "index.html")
```

This allows for Unboundtest to be spun up with dynamic IP:Ports by an orchestration framework instead of relying on Docker.